### PR TITLE
Grammar correction

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1662,7 +1662,7 @@ pub mod preset {
 
 	/// Generates error description.
 	pub fn gen_error_description(err_info: &ErrorInfo) -> String {
-		let mut description = String::from("Error occured in parseing ");
+		let mut description = String::from("Parse error: ");
 		match &err_info.0 {
 			MiddleArg::Normal(name) => {
 				description.push_str("arg:");


### PR DESCRIPTION
There were 2 spelling mistakes on the word *parseing* which should be *parsing* and *occured* which should be *occurred*

The description "Error occured in parseing" is a little over complicated, so suggesting for a more succinct "Parse error: "